### PR TITLE
Add new printing methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Este proyecto permite probar distintos métodos de impresión para una impresora
 EPSON TM-U950. Proporciona una interfaz gráfica donde se puede seleccionar el
 método de impresión y la impresora instalada en el sistema, incluso si se
-encuentra fuera de línea.
+encuentra fuera de línea. Se incluyen alternativas de impresión como `os.startfile`, `win32ui`, generación de PDF con ReportLab y comandos ESC/POS.
 
 ## Requisitos
 
@@ -27,3 +27,12 @@ python menu_impresion.py
 
 Selecciona la impresora y el método de impresión deseado para enviar una
 factura de prueba o ver una vista previa.
+
+Los métodos disponibles incluyen:
+
+- RAW con `win32print`
+- RAW con tabulaciones o CRLF
+- Impresión mediante `win32ui`
+- Uso de `os.startfile`
+- Generación de PDF con ReportLab
+- Envío de comandos ESC/POS (si la impresora lo soporta)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pywin32
+reportlab
+python-escpos


### PR DESCRIPTION
## Summary
- implement optional printing methods using win32ui, os.startfile, ReportLab PDF and ESC/POS
- list these new options in the GUI and README
- note extra dependencies

## Testing
- `python -m py_compile menu_impresion.py`
- `pip install -r requirements.txt` *(fails: no matching distribution for pywin32)*

------
https://chatgpt.com/codex/tasks/task_e_685a0fbe5b648323b4c0ec1a0f3fac16