### PR TITLE
Improve slip 4 initialization

### DIFF
--- a/menu_impresion.py
+++ b/menu_impresion.py
@@ -127,9 +127,11 @@ def imprimir_factura_raw(printer_name):
     slip_cmd = SLIP4_MODE
     try:
         hprinter = win32print.OpenPrinter(printer_name)
+        # Enviar comando de modo slip antes de iniciar la página
+        win32print.WritePrinter(hprinter, slip_cmd)
         win32print.StartDocPrinter(hprinter, 1, ("Factura RAW", None, "RAW"))
         win32print.StartPagePrinter(hprinter)
-        win32print.WritePrinter(hprinter, slip_cmd + factura_raw.encode("utf-8"))
+        win32print.WritePrinter(hprinter, factura_raw.encode("utf-8"))
         win32print.EndPagePrinter(hprinter)
         win32print.EndDocPrinter(hprinter)
         win32print.ClosePrinter(hprinter)
@@ -146,9 +148,10 @@ def imprimir_factura_raw_simple(printer_name):
     slip_cmd = SLIP4_MODE
     try:
         hprinter = win32print.OpenPrinter(printer_name)
+        win32print.WritePrinter(hprinter, slip_cmd)
         win32print.StartDocPrinter(hprinter, 1, ("Factura RAW Simple", None, "RAW"))
         win32print.StartPagePrinter(hprinter)
-        win32print.WritePrinter(hprinter, slip_cmd + factura.encode("utf-8"))
+        win32print.WritePrinter(hprinter, factura.encode("utf-8"))
         win32print.EndPagePrinter(hprinter)
         win32print.EndDocPrinter(hprinter)
         win32print.ClosePrinter(hprinter)
@@ -172,9 +175,10 @@ def imprimir_factura_raw_tabs(printer_name):
     slip_cmd = SLIP4_MODE
     try:
         hprinter = win32print.OpenPrinter(printer_name)
+        win32print.WritePrinter(hprinter, slip_cmd)
         win32print.StartDocPrinter(hprinter, 1, ("Factura RAW Tabs", None, "RAW"))
         win32print.StartPagePrinter(hprinter)
-        win32print.WritePrinter(hprinter, slip_cmd + factura.encode("utf-8"))
+        win32print.WritePrinter(hprinter, factura.encode("utf-8"))
         win32print.EndPagePrinter(hprinter)
         win32print.EndDocPrinter(hprinter)
         win32print.ClosePrinter(hprinter)
@@ -198,9 +202,10 @@ def imprimir_factura_raw_crlf(printer_name):
     slip_cmd = SLIP4_MODE
     try:
         hprinter = win32print.OpenPrinter(printer_name)
+        win32print.WritePrinter(hprinter, slip_cmd)
         win32print.StartDocPrinter(hprinter, 1, ("Factura RAW CRLF", None, "RAW"))
         win32print.StartPagePrinter(hprinter)
-        win32print.WritePrinter(hprinter, slip_cmd + factura.encode("utf-8"))
+        win32print.WritePrinter(hprinter, factura.encode("utf-8"))
         win32print.EndPagePrinter(hprinter)
         win32print.EndDocPrinter(hprinter)
         win32print.ClosePrinter(hprinter)


### PR DESCRIPTION
## Summary
- send slip command before starting the print job so the printer switches to invoice mode

## Testing
- `python -m py_compile menu_impresion.py`

------
https://chatgpt.com/codex/tasks/task_e_685ae29892f48323a66a96fce8637e65