### PR TITLE
Remove unused SLIP_MODE constant

### DIFF
--- a/menu_impresion.py
+++ b/menu_impresion.py
@@ -23,9 +23,8 @@ except Exception:
     Serial = None
 
 # Comandos de la EPSON TM-U950 para seleccionar el modo de impresi\u00f3n.
-# SLIP_MODE habilita la bandeja de formularios y SLIP4_MODE indica que
-# se utilizar\u00e1 la posici\u00f3n "slip 4" recomendada para facturas.
-SLIP_MODE = b"\x1B\x69"
+# SLIP4_MODE indica que se utilizará la posición "slip 4" recomendada
+# para facturas en la bandeja de formularios.
 SLIP4_MODE = b"\x1B\x69\x04"
 
 try:


### PR DESCRIPTION
## Summary
- drop `SLIP_MODE` constant
- update comment to refer only to `SLIP4_MODE`

## Testing
- `python -m py_compile menu_impresion.py`

------
https://chatgpt.com/codex/tasks/task_e_685af9f0636c8323b7ad5e0165f26a85