### PR TITLE
Improve print font

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ Los métodos disponibles incluyen únicamente variantes de `win32ui`:
 - Alineado por espacios
 - Alineado con tabulaciones
 - Alineado con CRLF
+
+## Fuente de impresión
+
+La aplicación intenta usar de forma predeterminada una fuente de matriz de
+puntos (`Dot Matrix`) para asemejar la salida de las impresoras de impacto.
+Puedes cambiar el nombre de la fuente modificando la constante
+`DEFAULT_FONT_NAME` en `menu_impresion.py`. Si la fuente no está instalada en
+el sistema se utilizará `Courier New` como alternativa.

--- a/menu_impresion.py
+++ b/menu_impresion.py
@@ -1,6 +1,8 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 
+DEFAULT_FONT_NAME = "Dot Matrix"
+
 # Intenta importar win32print, si no está disponible muestra un error al intentar imprimir
 try:
     import win32print
@@ -26,11 +28,18 @@ def cm_a_twips(valor_cm: float) -> int:
     return round(valor_cm * 566.93)
 
 
-def seleccionar_fuente(dc, puntos=12):
-    """Crea y selecciona en el DC una fuente de *puntos* puntos."""
+def seleccionar_fuente(dc, puntos=12, nombre=DEFAULT_FONT_NAME):
+    """Crea y selecciona en el DC una fuente *nombre* de *puntos* puntos.
+
+    Si la fuente no está disponible se utilizará ``Courier New`` como
+    alternativa.
+    """
     if win32ui is None:
         return None, None
-    font = win32ui.CreateFont({"name": "Arial", "height": -puntos * 20})
+    try:
+        font = win32ui.CreateFont({"name": nombre, "height": -puntos * 20})
+    except Exception:
+        font = win32ui.CreateFont({"name": "Courier New", "height": -puntos * 20})
     old = dc.SelectObject(font)
     return font, old
 


### PR DESCRIPTION
## Summary
- add `DEFAULT_FONT_NAME` constant
- fall back to `Courier New` when dot matrix font isn't available
- document default dot matrix font

## Testing
- `python -m py_compile menu_impresion.py`


------
https://chatgpt.com/codex/tasks/task_e_685b14adfc94832392f76dde4d34cd59