### PR TITLE
Fix coordinate mapping to prevent text cutoff

### DIFF
--- a/menu_impresion.py
+++ b/menu_impresion.py
@@ -41,9 +41,10 @@ def configurar_mapeo(dc):
     dc.SetMapMode(win32con.MM_TWIPS)
     ancho = dc.GetDeviceCaps(win32con.HORZRES)
     alto = dc.GetDeviceCaps(win32con.VERTRES)
-    # PyCDC no expone los métodos *Ex, por lo que utilizamos las variantes
-    # simples que aceptan una tupla como parámetro.
+    # Alinear el origen lógico con la esquina superior izquierda
+    dc.SetWindowOrg((0, 0))
     dc.SetWindowExt((cm_a_twips(27.5), cm_a_twips(16.6)))
+    dc.SetViewportOrg((0, alto))
     dc.SetViewportExt((ancho, -alto))
 
 
@@ -141,7 +142,7 @@ def imprimir_factura_win32ui(printer_name):
         font, old_font = seleccionar_fuente(dc, 12)
 
         def draw(x_cm, y_cm, texto):
-            dc.TextOut(cm_a_twips(x_cm), -cm_a_twips(y_cm), texto)
+            dc.TextOut(cm_a_twips(x_cm), cm_a_twips(y_cm), texto)
 
         # Encabezado (solo datos)
         header_pos = [
@@ -259,7 +260,7 @@ def imprimir_factura_win32ui_espacios(printer_name):
         font, old_font = seleccionar_fuente(dc, 12)
 
         def draw(x_cm, y_cm, texto):
-            dc.TextOut(cm_a_twips(x_cm), -cm_a_twips(y_cm), texto)
+            dc.TextOut(cm_a_twips(x_cm), cm_a_twips(y_cm), texto)
 
         header_order = [
             "cliente",
@@ -365,7 +366,7 @@ def imprimir_factura_win32ui_tabs(printer_name):
         font, old_font = seleccionar_fuente(dc, 12)
 
         def draw(x_cm, y_cm, texto):
-            dc.TextOut(cm_a_twips(x_cm), -cm_a_twips(y_cm), texto)
+            dc.TextOut(cm_a_twips(x_cm), cm_a_twips(y_cm), texto)
 
         header_order = [
             "cliente",
@@ -469,7 +470,7 @@ def imprimir_factura_win32ui_crlf(printer_name):
         font, old_font = seleccionar_fuente(dc, 12)
 
         def draw(x_cm, y_cm, texto):
-            dc.TextOut(cm_a_twips(x_cm), -cm_a_twips(y_cm), texto)
+            dc.TextOut(cm_a_twips(x_cm), cm_a_twips(y_cm), texto)
 
         header_order = [
             "cliente",


### PR DESCRIPTION
## Summary
- adjust map mode and viewport alignment to correct absolute positioning
- drop inverted Y coordinate in text helper

## Testing
- `python -m py_compile menu_impresion.py`

------
https://chatgpt.com/codex/tasks/task_e_685b15166fe08323bcb12b8b43a5fecf