### PR TITLE
Fix dot matrix font handling

### DIFF
--- a/menu_impresion.py
+++ b/menu_impresion.py
@@ -1,6 +1,10 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 
+# Fuente predeterminada para las impresiones. Cambia el valor si tu impresora
+# ofrece un nombre distinto para su tipo de letra de matriz de puntos.
+DEFAULT_FONT_NAME = "Dot Matrix"
+
 # Intenta importar win32print, si no está disponible muestra un error al intentar imprimir
 try:
     import win32print
@@ -26,11 +30,17 @@ def cm_a_twips(valor_cm: float) -> int:
     return round(valor_cm * 566.93)
 
 
-def seleccionar_fuente(dc, puntos=12):
-    """Crea y selecciona en el DC una fuente de *puntos* puntos."""
+def seleccionar_fuente(dc, puntos=12, nombre=DEFAULT_FONT_NAME):
+    """Crea y selecciona en el DC una fuente *nombre* de *puntos* puntos.
+
+    Si la fuente no está disponible se utiliza ``Courier New`` como alternativa.
+    """
     if win32ui is None:
         return None, None
-    font = win32ui.CreateFont({"name": "Arial", "height": -puntos * 20})
+    try:
+        font = win32ui.CreateFont({"name": nombre, "height": -puntos * 20})
+    except Exception:
+        font = win32ui.CreateFont({"name": "Courier New", "height": -puntos * 20})
     old = dc.SelectObject(font)
     return font, old
 


### PR DESCRIPTION
## Summary
- add `DEFAULT_FONT_NAME` constant to configure the printing font
- fall back to `Courier New` if the chosen font isn't installed

## Testing
- `python -m py_compile menu_impresion.py`


------
https://chatgpt.com/codex/tasks/task_e_685b1f99c6508323ba65457d644b0828