### PR TITLE
Retrieve printer offsets for layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ Si notas que los caracteres se ven cortados o poco legibles, verifica qué
 fuentes incluye el driver de tu impresora (por ejemplo, "EPSON Draft 10cpi" o
 "EPSON Roman 12cpi") e indica el nombre exacto en la constante
 `DEFAULT_FONT_NAME` de `menu_impresion.py`.
+
+## Configuración de la página
+
+La función `configurar_mapeo` asume que la factura ocupa un área de
+16.6 × 27.5 cm. Estos valores funcionan para la TM‑U950 pero pueden variar
+según el modelo y el tamaño de papel. El origen de la vista (offsets
+`PHYSICALOFFSETX` y `PHYSICALOFFSETY`) se consulta directamente a la
+impresora porque cada driver aplica desplazamientos diferentes.

--- a/menu_impresion.py
+++ b/menu_impresion.py
@@ -98,16 +98,23 @@ def eliminar_fuente(font):
             pass
 
 def configurar_mapeo(dc):
-    """Configura el mapeo para que 16.6 cm x 27.5 cm coincidan con el área imprimible."""
+    """Configura el mapeo del DC para coincidir con el tamaño de la factura.
+
+    Se asume un papel de 16.6 × 27.5 cm. Los desplazamientos (`PHYSICALOFFSETX`,
+    `PHYSICALOFFSETY`) se leen de la impresora y pueden variar entre modelos.
+    """
     if not win32con:
         return
     dc.SetMapMode(win32con.MM_TWIPS)
     ancho = dc.GetDeviceCaps(win32con.HORZRES)
     alto = dc.GetDeviceCaps(win32con.VERTRES)
+    offset_x = dc.GetDeviceCaps(win32con.PHYSICALOFFSETX)
+    offset_y = dc.GetDeviceCaps(win32con.PHYSICALOFFSETY)
     # PyCDC no expone los métodos *Ex, por lo que utilizamos las variantes
     # simples que aceptan una tupla como parámetro.
     dc.SetWindowExt((cm_a_twips(16.6), cm_a_twips(27.5)))
     dc.SetViewportExt((ancho, -alto))
+    dc.SetViewportOrg((-offset_x, offset_y))
 
 
 def activar_modo_slip(printer_name: str) -> bool:


### PR DESCRIPTION
## Summary
- query PHYSICALOFFSETX and PHYSICALOFFSETY to align the viewport
- document paper size assumption in README

## Testing
- `python -m py_compile menu_impresion.py`
- `flake8 menu_impresion.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b27b975e48323866270471af9b1db