### PR TITLE
Ajustar coordenada 'venta a cuenta de'

### DIFF
--- a/menu_impresion.py
+++ b/menu_impresion.py
@@ -45,7 +45,7 @@ HEADER_COORDS = {
     "no_rem": (7.62, 7.50),
     "nit": (11.43, 6.40),
     "orden_no": (12.07, 7.50),
-    "venta_cuenta_de": (11.43, 8.00),
+    "venta_cuenta_de": (10.70, 8.00),
     "fecha_nota_ant": (11.75, 8.50),
 }
 


### PR DESCRIPTION
## Summary
- set `venta_cuenta_de` coordinates to x=10.70cm y=8.00cm

## Testing
- `python -m py_compile menu_impresion.py`

------
https://chatgpt.com/codex/tasks/task_e_685b56ea6f948323b8f1697e8ce43e87