### PR TITLE
Add program printing method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Los métodos disponibles incluyen únicamente variantes de `win32ui`:
 - Alineado por espacios
 - Alineado con tabulaciones
 - Alineado con CRLF
+- Impresión de programa
 
 ## Fuente de impresión
 


### PR DESCRIPTION
## Summary
- implement `imprimir_factura_programa` as a basic approximation of the external program's printing style
- expose the new method from the GUI and update README

## Testing
- `python -m py_compile menu_impresion.py`


------
https://chatgpt.com/codex/tasks/task_e_685c399b5a8c8323abb5d06e8d1649b1